### PR TITLE
Native macOS: Tastenkürzel, Fensterstatus-Wiederherstellung, Multi-Window

### DIFF
--- a/PokeJournal/PokeJournal/AppCommands.swift
+++ b/PokeJournal/PokeJournal/AppCommands.swift
@@ -1,0 +1,53 @@
+//
+//  AppCommands.swift
+//  PokéJournal
+//
+
+import SwiftUI
+
+// MARK: - Focused Values
+
+extension FocusedValues {
+    @Entry var selectedTab: Binding<Int>? = nil
+    @Entry var reloadAction: (() -> Void)? = nil
+}
+
+// MARK: - Commands
+
+struct AppCommands: Commands {
+    @FocusedSceneValue(\.selectedTab) var selectedTabBinding: Binding<Int>?
+    @FocusedSceneValue(\.reloadAction) var reloadAction: (() -> Void)?
+
+    var body: some Commands {
+        // Remove "New Window" from File menu — we handle it ourselves via context menu
+        CommandGroup(replacing: .newItem) { }
+
+        CommandMenu("Ansicht") {
+            Button("Aktualisieren") { reloadAction?() }
+                .keyboardShortcut("r", modifiers: .command)
+                .disabled(reloadAction == nil)
+
+            Divider()
+
+            Button("Sessions") { selectedTabBinding?.wrappedValue = 0 }
+                .keyboardShortcut("1", modifiers: .command)
+                .disabled(selectedTabBinding == nil)
+
+            Button("Timeline") { selectedTabBinding?.wrappedValue = 1 }
+                .keyboardShortcut("2", modifiers: .command)
+                .disabled(selectedTabBinding == nil)
+
+            Button("Heatmap") { selectedTabBinding?.wrappedValue = 2 }
+                .keyboardShortcut("3", modifiers: .command)
+                .disabled(selectedTabBinding == nil)
+
+            Button("Team-Analyse") { selectedTabBinding?.wrappedValue = 3 }
+                .keyboardShortcut("4", modifiers: .command)
+                .disabled(selectedTabBinding == nil)
+
+            Button("Team-Entwicklung") { selectedTabBinding?.wrappedValue = 4 }
+                .keyboardShortcut("5", modifiers: .command)
+                .disabled(selectedTabBinding == nil)
+        }
+    }
+}

--- a/PokeJournal/PokeJournal/AppCommands.swift
+++ b/PokeJournal/PokeJournal/AppCommands.swift
@@ -15,8 +15,8 @@ extension FocusedValues {
 // MARK: - Commands
 
 struct AppCommands: Commands {
-    @FocusedSceneValue(\.selectedTab) var selectedTabBinding: Binding<Int>?
-    @FocusedSceneValue(\.reloadAction) var reloadAction: (() -> Void)?
+    @FocusedValue(\.selectedTab) var selectedTabBinding: Binding<Int>?
+    @FocusedValue(\.reloadAction) var reloadAction: (() -> Void)?
 
     var body: some Commands {
         // Remove "New Window" from File menu — we handle it ourselves via context menu

--- a/PokeJournal/PokeJournal/ContentView.swift
+++ b/PokeJournal/PokeJournal/ContentView.swift
@@ -117,6 +117,7 @@ struct ContentView: View {
     }
 
     private func reload() {
+        selectedGame = nil
         Task { await dataLoader.reloadData(context: modelContext) }
     }
 }

--- a/PokeJournal/PokeJournal/ContentView.swift
+++ b/PokeJournal/PokeJournal/ContentView.swift
@@ -14,6 +14,9 @@ struct ContentView: View {
     @State private var showSettings = false
     @State private var dataLoader = DataLoader()
 
+    // Persists the selected game across app launches (per window scene)
+    @SceneStorage("selectedGameName") private var selectedGameName: String?
+
     private var vaultManager = VaultManager.shared
 
     var body: some View {
@@ -37,6 +40,16 @@ struct ContentView: View {
                 }
             }
         }
+        // Persist selection
+        .onChange(of: selectedGame) { _, game in
+            selectedGameName = game?.name
+        }
+        // Restore selection once games are loaded
+        .onChange(of: games) { _, newGames in
+            if selectedGame == nil, let name = selectedGameName {
+                selectedGame = newGames.first { $0.name == name }
+            }
+        }
     }
 
     @ViewBuilder
@@ -51,12 +64,7 @@ struct ContentView: View {
                     }
 
                     ToolbarItem(placement: .automatic) {
-                        Button(action: {
-                            selectedGame = nil
-                            Task {
-                                await dataLoader.reloadData(context: modelContext)
-                            }
-                        }) {
+                        Button(action: reload) {
                             Label("Aktualisieren", systemImage: "arrow.clockwise")
                         }
                         .disabled(dataLoader.isLoading)
@@ -76,6 +84,7 @@ struct ContentView: View {
             }
         }
         .navigationSplitViewColumnWidth(min: 200, ideal: 250, max: 350)
+        .focusedSceneValue(\.reloadAction, reload)
         .sheet(isPresented: $showSettings) {
             NavigationStack {
                 SettingsView()
@@ -105,6 +114,10 @@ struct ContentView: View {
                 Text(error)
             }
         }
+    }
+
+    private func reload() {
+        Task { await dataLoader.reloadData(context: modelContext) }
     }
 }
 

--- a/PokeJournal/PokeJournal/Poke_JournalApp.swift
+++ b/PokeJournal/PokeJournal/Poke_JournalApp.swift
@@ -29,6 +29,18 @@ struct Poke_JournalApp: App {
             ContentView()
         }
         .modelContainer(sharedModelContainer)
+        .commands {
+            AppCommands()
+        }
+
+        // Standalone game windows opened via context menu
+        WindowGroup("Spiel", id: "game", for: String.self) { $gameName in
+            if let name = gameName {
+                GameWindowView(gameName: name)
+                    .modelContainer(sharedModelContainer)
+            }
+        }
+        .defaultSize(width: 960, height: 720)
 
         Settings {
             SettingsView()

--- a/PokeJournal/PokeJournal/Views/GameDetailView.swift
+++ b/PokeJournal/PokeJournal/Views/GameDetailView.swift
@@ -8,47 +8,58 @@ import SwiftData
 
 struct GameDetailView: View {
     let game: Game
-    @State private var selectedTab = 0
+    @SceneStorage("selectedTab") private var selectedTab = 0
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                GameHeaderView(game: game)
-
-                StatsCardsView(game: game)
-
-                if !game.currentTeam.isEmpty {
-                    CurrentTeamView(team: game.currentTeam)
-                }
-
-                Picker("Ansicht", selection: $selectedTab) {
-                    Text("Sessions").tag(0)
-                    Text("Timeline").tag(1)
-                    Text("Heatmap").tag(2)
-                    Text("Team-Analyse").tag(3)
-                    Text("Team-Entwicklung").tag(4)
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal)
-
-                switch selectedTab {
-                case 0:
-                    SessionsListView(game: game)
-                case 1:
-                    TimelineView(game: game)
-                case 2:
-                    HeatmapView(game: game)
-                case 3:
-                    TeamAnalysisView(game: game)
-                case 4:
-                    TeamEvolutionView(game: game)
-                default:
-                    EmptyView()
-                }
-            }
-            .padding()
+            GameDetailContent(game: game, selectedTab: $selectedTab)
         }
         .navigationTitle(game.displayName)
+        .focusedSceneValue(\.selectedTab, $selectedTab)
+    }
+}
+
+/// Shared content used by both the split-view detail pane and standalone game windows.
+struct GameDetailContent: View {
+    let game: Game
+    @Binding var selectedTab: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            GameHeaderView(game: game)
+
+            StatsCardsView(game: game)
+
+            if !game.currentTeam.isEmpty {
+                CurrentTeamView(team: game.currentTeam)
+            }
+
+            Picker("Ansicht", selection: $selectedTab) {
+                Text("Sessions").tag(0)
+                Text("Timeline").tag(1)
+                Text("Heatmap").tag(2)
+                Text("Team-Analyse").tag(3)
+                Text("Team-Entwicklung").tag(4)
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+
+            switch selectedTab {
+            case 0:
+                SessionsListView(game: game)
+            case 1:
+                TimelineView(game: game)
+            case 2:
+                HeatmapView(game: game)
+            case 3:
+                TeamAnalysisView(game: game)
+            case 4:
+                TeamEvolutionView(game: game)
+            default:
+                EmptyView()
+            }
+        }
+        .padding()
     }
 }
 

--- a/PokeJournal/PokeJournal/Views/GameListView.swift
+++ b/PokeJournal/PokeJournal/Views/GameListView.swift
@@ -9,6 +9,7 @@ import SwiftData
 struct GameListView: View {
     @Query(sort: \Game.name) private var games: [Game]
     @Binding var selectedGame: Game?
+    @Environment(\.openWindow) private var openWindow
 
     private var filteredGames: [Game] {
         games.filter { !$0.isHidden && Game.isRPGGenre($0.genre) }
@@ -21,6 +22,10 @@ struct GameListView: View {
                     .tag(game)
                     .accessibilityIdentifier("gameRow_\(game.name)")
                     .contextMenu {
+                        Button("In neuem Fenster öffnen") {
+                            openWindow(id: "game", value: game.name)
+                        }
+                        Divider()
                         Button("Ausblenden") {
                             game.isHidden = true
                             if selectedGame == game {

--- a/PokeJournal/PokeJournal/Views/GameWindowView.swift
+++ b/PokeJournal/PokeJournal/Views/GameWindowView.swift
@@ -1,0 +1,38 @@
+//
+//  GameWindowView.swift
+//  PokéJournal
+//
+
+import SwiftUI
+import SwiftData
+
+/// Standalone window that shows a single game's detail view.
+/// Opened via context menu "In neuem Fenster öffnen".
+struct GameWindowView: View {
+    let gameName: String
+
+    @Query private var games: [Game]
+
+    private var game: Game? {
+        games.first { $0.name == gameName }
+    }
+
+    var body: some View {
+        NavigationStack {
+            if let game {
+                GameDetailView(game: game)
+            } else {
+                ContentUnavailableView(
+                    "Spiel nicht gefunden",
+                    systemImage: "questionmark.circle",
+                    description: Text(gameName)
+                )
+            }
+        }
+    }
+
+    init(gameName: String) {
+        self.gameName = gameName
+        _games = Query(filter: #Predicate { $0.name == gameName })
+    }
+}


### PR DESCRIPTION
## Summary

- **Tastenkürzel + Ansicht-Menü**: Neuer `AppCommands` Struct mit einem top-level "Ansicht" Menü. `⌘1–5` wechseln die Tabs (Sessions, Timeline, Heatmap, Team-Analyse, Team-Entwicklung) und `⌘R` lädt die Daten neu. Menüeinträge werden via `focusedSceneValue` verdrahtet und deaktivieren sich automatisch wenn kein Spiel geöffnet ist.

- **Fensterstatus-Wiederherstellung**: `@SceneStorage` speichert jetzt das ausgewählte Spiel (per Name) und den aktiven Tab pro Fenster. Die App öffnet sich nach einem Neustart wieder beim zuletzt angezeigten Spiel und Tab.

- **Mehrere Fenster**: Rechtsklick auf ein Spiel → "In neuem Fenster öffnen" öffnet ein eigenständiges `GameWindowView` (960×720) mit eigenem `WindowGroup`. Jedes Fenster hat unabhängige Tab-Zustand, Tastenkürzel und Scene Storage. `GameDetailContent` wurde extrahiert damit dieselbe UI ohne Duplikate geteilt wird.

## Changed files

| File | Change |
|---|---|
| `AppCommands.swift` | New — `FocusedValues` extensions + `AppCommands` Commands struct |
| `Views/GameWindowView.swift` | New — standalone game window using `@Query` by name |
| `Poke_JournalApp.swift` | Add second `WindowGroup(id: "game")` + `.commands { AppCommands() }` |
| `ContentView.swift` | `@SceneStorage` for selected game, `focusedSceneValue` for reload |
| `Views/GameDetailView.swift` | `@SceneStorage` for tab, extract `GameDetailContent`, `focusedSceneValue` for tab |
| `Views/GameListView.swift` | "In neuem Fenster öffnen" context menu item |

## Test plan

- [ ] App starten → zuletzt ausgewähltes Spiel wird automatisch wiederhergestellt
- [ ] Spiel auswählen, zu Timeline-Tab wechseln, App beenden, neu starten → selbes Spiel + selber Tab
- [ ] Rechtsklick auf ein Spiel → "In neuem Fenster öffnen" → eigenständiges Fenster öffnet sich
- [ ] `⌘R` lädt Daten neu (Spinner erscheint kurz)
- [ ] `⌘1–5` wechseln Tabs wenn ein Spiel ausgewählt ist; alle deaktiviert wenn kein Spiel ausgewählt
- [ ] Ansicht-Menü zeigt korrekten Deaktivierungs-Zustand je nach Auswahl

https://claude.ai/code/session_013viaoidFGoZdXkvu6LUtih